### PR TITLE
fix: disable dark theme support until finished

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -20,7 +20,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
   }, []);
 
   return (
-    <div className={clsx("example-debugging-disabled", "utrecht-theme", "utrecht-theme--media-query-color-scheme")}>
+    <div className={clsx("example-debugging-disabled", "utrecht-theme")}>
       <Component {...pageProps} />
     </div>
   );


### PR DESCRIPTION
Disables dark theme as the dark theme styling in incomplete and not required for MVP.