### PR TITLE
feat: support registration type in state context

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,12 +4,16 @@ import { appWithTranslation } from "next-i18next";
 import "@utrecht/design-tokens/dist/index.css";
 import "@utrecht/component-library-css/dist/index.css";
 import "@utrecht/component-library-css/dist/html.css";
-import { useEffect } from "react";
-import { matomo } from "../src/matomo";
+import { useEffect, useState } from "react";
 import "../styles/globals.scss";
 import "../styles/utrecht-theme.css";
+import { MarriageOptionsContext } from "../src/context/MarriageOptionsContext";
+import { HuwelijksplannerState, initialState } from "../src/data/huwelijksplanner-state";
+import { matomo } from "../src/matomo";
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
+  const [marriageOptions, setMarriageOptions] = useState<HuwelijksplannerState>(initialState);
+
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_MATOMO_URL) {
       matomo({
@@ -21,7 +25,9 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
 
   return (
     <div className={clsx("example-debugging-disabled", "utrecht-theme")}>
-      <Component {...pageProps} />
+      <MarriageOptionsContext.Provider value={[marriageOptions, setMarriageOptions]}>
+        <Component {...pageProps} />
+      </MarriageOptionsContext.Provider>
     </div>
   );
 };

--- a/pages/trouw-opties/index.tsx
+++ b/pages/trouw-opties/index.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { FormEvent, useState } from "react";
+import { FormEvent, useContext, useState } from "react";
 import {
   Aside,
   BackLink,
@@ -24,6 +24,8 @@ import {
 } from "../../src/components";
 import { PageFooterTemplate } from "../../src/components/huwelijksplanner/PageFooterTemplate";
 import { PageHeaderTemplate } from "../../src/components/huwelijksplanner/PageHeaderTemplate";
+import { MarriageOptionsContext } from "../../src/context/MarriageOptionsContext";
+import { RegistrationType } from "../../src/data/huwelijksplanner-state";
 
 export const getServerSideProps = async ({ locale }: { locale: string }) => ({
   props: {
@@ -33,16 +35,12 @@ export const getServerSideProps = async ({ locale }: { locale: string }) => ({
 
 export default function MultistepForm1() {
   const { t } = useTranslation(["common", "huwelijksplanner-step-1"]);
-  const { push } = useRouter();
-  const [weddingOptions, setWeddingOptions] = useState<string | undefined>();
+  const { replace } = useRouter();
+  const [marriageOptions, setMarriageOptions] = useContext(MarriageOptionsContext);
 
-  const onWeddingOptionsSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    push(`/trouw-opties/${weddingOptions}`);
-  };
-
-  const onWeddingOptionsClick = (event: any) => {
-    setWeddingOptions(event.target.value);
+  const onWeddingOptionsSubmit = (weddingType: RegistrationType) => {
+    setMarriageOptions({ ...marriageOptions, "registration-type": weddingType });
+    replace(`/trouw-opties/${weddingType}`);
   };
 
   return (
@@ -67,29 +65,25 @@ export default function MultistepForm1() {
                   {/*TODO: Step indicator component */}
                   <Paragraph lead>{t("common:step-n-of-m", { n: 1, m: 5 })} — Kies wat je wil</Paragraph>
                 </HeadingGroup>
-                <form onSubmit={onWeddingOptionsSubmit}>
-                  <Heading2>Wij willen trouwen</Heading2>
-                  <Button
-                    type="submit"
-                    name="type"
-                    value="huwelijk"
-                    appearance="primary-action-button"
-                    onClick={onWeddingOptionsClick}
-                  >
-                    Trouwen plannen <UtrechtIconArrow />
-                  </Button>
-                  <Heading2>Wij willen een geregistreerd partnerschap</Heading2>
-                  <Button
-                    type="submit"
-                    name="type"
-                    value="geregistreerd-partnerschap"
-                    appearance="primary-action-button"
-                    onClick={onWeddingOptionsClick}
-                  >
-                    Geregistreerd partnerschap plannen
-                    <UtrechtIconArrow />
-                  </Button>
-                </form>
+                <Heading2>Wij willen trouwen</Heading2>
+                <Button
+                  name="type"
+                  value="huwelijk"
+                  appearance="primary-action-button"
+                  onClick={() => onWeddingOptionsSubmit("huwelijk")}
+                >
+                  Trouwen plannen <UtrechtIconArrow />
+                </Button>
+                <Heading2>Wij willen een geregistreerd partnerschap</Heading2>
+                <Button
+                  name="type"
+                  value="geregistreerd-partnerschap"
+                  appearance="primary-action-button"
+                  onClick={() => onWeddingOptionsSubmit("geregistreerd-partnerschap")}
+                >
+                  Geregistreerd partnerschap plannen
+                  <UtrechtIconArrow />
+                </Button>
                 <Aside>
                   <Heading2>Meer informatie</Heading2>
                   <Paragraph>

--- a/src/context/MarriageOptionsContext.ts
+++ b/src/context/MarriageOptionsContext.ts
@@ -1,0 +1,7 @@
+import { createContext, SetStateAction } from 'react';
+import { HuwelijksplannerInput, HuwelijksplannerState, initialState } from '../data/huwelijksplanner-state';
+
+export const MarriageOptionsContext = createContext<[HuwelijksplannerState, (_: HuwelijksplannerState) => void]>([
+  initialState,
+  () => null,
+]);

--- a/src/data/huwelijksplanner-state.ts
+++ b/src/data/huwelijksplanner-state.ts
@@ -151,7 +151,7 @@ export type CeremonyType =
   | 'geregistreerd-partnerschap'
   | 'uitgebreid-huwelijk';
 
-export interface TODO {
+export interface HuwelijksplannerState {
   partnerInvitation?: Invitee;
   partners: HuwelijksplannerPartner[];
   witnesses: Witness[];
@@ -174,9 +174,7 @@ export interface TODO {
   orderProductEndDate?: string;
 }
 
-export type HuwelijksplannerState = TODO;
-
-export type HuwelijksplannerInput = Partial<TODO>;
+export type HuwelijksplannerInput = Partial<HuwelijksplannerState>;
 
 export const initialState: HuwelijksplannerState = {
   partners: [],


### PR DESCRIPTION
This change adds a MarriageOptionsContext that we can use anywhere in the application to keep track of user decisions and avoid duplicate API calls. 