### PR TITLE
[Step 2] Add API requests and conditional rendering to planning page

### DIFF
--- a/pages/trouw-opties/[slug].tsx
+++ b/pages/trouw-opties/[slug].tsx
@@ -4,7 +4,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { ChangeEvent, FormEvent, useCallback, useEffect, useState } from "react";
+import { FormEvent } from "react";
 import {
   Aside,
   BackLink,
@@ -12,10 +12,7 @@ import {
   ButtonGroup,
   Calendar,
   Document,
-  Fieldset,
-  FieldsetLegend,
   FormField,
-  FormLabel,
   Heading1,
   Heading2,
   HeadingGroup,
@@ -26,14 +23,11 @@ import {
   PageFooter,
   PageHeader,
   Paragraph,
-  RadioButton2,
   SkipLink,
   Surface,
-  TimeValue,
 } from "../../src/components";
 import { PageFooterTemplate } from "../../src/components/huwelijksplanner/PageFooterTemplate";
 import { PageHeaderTemplate } from "../../src/components/huwelijksplanner/PageHeaderTemplate";
-import { CalendarEvent } from "../../src/data/huwelijksplanner-state";
 import { AvailabilitycheckService } from "../../src/generated";
 
 export const getServerSideProps = async ({ locale }: { locale: string }) => ({
@@ -48,11 +42,17 @@ const PlanningFormPage: NextPage = () => {
 
   const onCalendarDateSelected = (date: Date) => {
     console.log(date);
+    console.log(date.getMonth());
 
     AvailabilitycheckService.availabilitycheckGetCollection({
+      resourcesCould: [
+        "0c0767af-e3d4-4ec0-ba9c-571b4c275b71",
+        "868da2b9-242d-4053-8e21-8a9ef66bd15c",
+        "31816698-10a0-41d6-8d0f-9108306491c0",
+      ],
       interval: "PT2H",
-      start: format(startOfMonth(date.getMonth()), "yyyy-MM-dd"),
-      stop: format(lastDayOfMonth(date.getMonth()), "yyyy-MM-dd"),
+      start: format(startOfMonth(date), "yyyy-MM-dd"),
+      stop: format(lastDayOfMonth(date), "yyyy-MM-dd"),
     }).then((result) => {
       console.log(result);
     });

--- a/pages/trouw-opties/[slug].tsx
+++ b/pages/trouw-opties/[slug].tsx
@@ -1,12 +1,11 @@
 import { FormLabel, RadioButton } from "@utrecht/component-library-react";
 import { endOfMonth, format, startOfMonth } from "date-fns";
-import _ from "lodash";
 import { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import React, { FormEvent, useContext, useEffect, useState } from "react";
+import React, { FormEvent, useContext, useState } from "react";
 import {
   Aside,
   BackLink,
@@ -35,9 +34,8 @@ import {
 import { PageFooterTemplate } from "../../src/components/huwelijksplanner/PageFooterTemplate";
 import { PageHeaderTemplate } from "../../src/components/huwelijksplanner/PageHeaderTemplate";
 import { MarriageOptionsContext } from "../../src/context/MarriageOptionsContext";
-import { CeremonyType } from "../../src/data/huwelijksplanner-state";
-import { resolveEmbedded } from "../../src/embedded";
-import { AvailabilitycheckService, SDGProduct, SdgproductService } from "../../src/generated";
+import { useAvailabilitycheckGetCollection } from "../../src/hooks/useAvailabilitycheckGetCollection";
+import { useSdgProductGetItem } from "../../src/hooks/useSdgProductGetItem";
 
 export const getServerSideProps = async ({ locale }: { locale: string }) => ({
   props: {
@@ -49,23 +47,6 @@ type CalendarData = {
   start: Date;
   end: Date;
   selectedDate?: Date;
-};
-
-type CeremonyData = {
-  type: CeremonyType;
-  id: string;
-  locationId: string;
-  ambtenaarId: string;
-};
-
-type AvailabilitySlot = {
-  resources: string[];
-  start: string;
-  stop: string;
-};
-
-type Availabilities = {
-  [key: string]: Array<AvailabilitySlot>;
 };
 
 type Event = {
@@ -81,38 +62,19 @@ const PlanningFormPage: NextPage = () => {
   const { locale = "nl", replace } = useRouter();
   const { t } = useTranslation(["common", "huwelijksplanner-step-2"]);
   const [marriageOptions, setMarriageOptions] = useContext(MarriageOptionsContext);
-  const [ceremonies, setCeremonies] = useState<CeremonyData[]>([]);
-  const [availabilities, setAvailabilities] = useState<Availabilities>({});
   const [calendarData, setCalendarData] = useState<CalendarData>({
     start: startOfMonth(Date.now()),
     end: endOfMonth(Date.now()),
     selectedDate: undefined,
   });
-  const [unavailableData, setUnavailableData] = useState<Event[]>([]);
 
-  useEffect(() => {
-    if (ceremonies.length === 0) return;
-    AvailabilitycheckService.availabilitycheckGetCollection({
-      resourcesCould: ceremonies.map((ceremony) => ceremony.id),
-      interval: "PT2H",
-      start: format(calendarData.start, dateFormat),
-      stop: format(calendarData.end, dateFormat),
-    }).then((response) => {
-      const availabilityResults: Availabilities = response as any;
-      setAvailabilities(availabilityResults);
-
-      const unavailableEvents: Event[] = [];
-      _.forEach(availabilityResults, (result, date) => {
-        if (!_.some(result, (r) => r.resources.length > 0)) {
-          unavailableEvents.push({
-            date: date,
-            disabled: true,
-          });
-        }
-      });
-      setUnavailableData(unavailableEvents);
-    });
-  }, [ceremonies, calendarData.start.toISOString()]);
+  const [ceremonyData, ceremoniesLoading, ceremonyError] = useSdgProductGetItem(marriageOptions.productId);
+  const [availabilityData, availabilityLoading, availabilityError] = useAvailabilitycheckGetCollection({
+    ceremonyData: ceremonyData,
+    interval: "PT2H",
+    start: calendarData.start,
+    stop: calendarData.end,
+  });
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -121,22 +83,6 @@ const PlanningFormPage: NextPage = () => {
   const onCalendarDateSelected = (date: Date) => {
     setCalendarData({ start: startOfMonth(date), end: endOfMonth(date), selectedDate: date });
   };
-
-  useEffect(() => {
-    if (!marriageOptions.productId) replace("/trouw-opties/");
-
-    SdgproductService.sdgproductGetItem({ id: marriageOptions.productId as string }).then((response) => {
-      const result = resolveEmbedded(response);
-      setCeremonies(
-        result.gerelateerdeProducten.map((ceremony: SDGProduct) => ({
-          id: ceremony.id as string,
-          type: ceremony.upnLabel as CeremonyType,
-          locationId: ceremony.gerelateerdeProducten[0].id,
-          ambtenaarId: ceremony.gerelateerdeProducten[0].gerelateerdeProducten[0].id,
-        }))
-      );
-    });
-  }, []);
 
   return (
     <Surface>
@@ -168,7 +114,7 @@ const PlanningFormPage: NextPage = () => {
                 <section>
                   <FormField>
                     <Calendar
-                      events={unavailableData}
+                      //events={unavailableData}
                       onCalendarClick={(date: string) => onCalendarDateSelected(new Date(date))}
                     />
                   </FormField>
@@ -177,11 +123,11 @@ const PlanningFormPage: NextPage = () => {
                       <p>
                         <DateValue dateTime={calendarData.selectedDate.toISOString()} locale={locale} />
                       </p>
-                      {ceremonies.map((ceremony, idx) => (
+                      {ceremonyData.map((ceremony, idx) => (
                         <Fieldset key={idx}>
                           <FieldsetLegend>{ceremony.type}</FieldsetLegend>
                           {calendarData.selectedDate &&
-                            availabilities[format(calendarData.selectedDate, dateFormat)]
+                            availabilityData[format(calendarData.selectedDate, dateFormat)]
                               ?.filter((slot) => slot.resources.includes(ceremony.id))
                               .map((slot, idx) => (
                                 <FormField key={idx} type="radio">

--- a/pages/trouw-opties/[slug].tsx
+++ b/pages/trouw-opties/[slug].tsx
@@ -1,3 +1,4 @@
+import { format, lastDayOfMonth, startOfMonth } from "date-fns";
 import { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
@@ -32,9 +33,8 @@ import {
 } from "../../src/components";
 import { PageFooterTemplate } from "../../src/components/huwelijksplanner/PageFooterTemplate";
 import { PageHeaderTemplate } from "../../src/components/huwelijksplanner/PageHeaderTemplate";
-import { calendars, CeremonyType } from "../../src/data/huwelijksplanner-state";
-import { Availability } from "../../src/generated";
-import { HuwelijksplannerAPI } from "../../src/openapi";
+import { CalendarEvent } from "../../src/data/huwelijksplanner-state";
+import { AvailabilitycheckService } from "../../src/generated";
 
 export const getServerSideProps = async ({ locale }: { locale: string }) => ({
   props: {
@@ -42,49 +42,24 @@ export const getServerSideProps = async ({ locale }: { locale: string }) => ({
   },
 });
 
-const BlogPost: NextPage = () => {
-  const { locale = "nl", push } = useRouter();
+const PlanningFormPage: NextPage = () => {
+  const { locale = "nl", replace } = useRouter();
   const { t } = useTranslation(["common", "huwelijksplanner-step-2"]);
 
-  const getEvents = (type: CeremonyType, date: string) => {
-    return calendars[type as keyof typeof calendars].filter((event) => event.startDateTime.startsWith(date));
-  };
+  const onCalendarDateSelected = (date: Date) => {
+    console.log(date);
 
-  const [, setResults] = useState<Availability[]>([]);
-
-  const [selectedDate, setSelectedDate] = useState("2021-04-14");
-  const [selectedLocationAndDate, setSelectedLocationAndDate] = useState<string | undefined>();
-
-  const loadEvents = useCallback(() => {
-    const today = new Date().toISOString().replace(/T.+/, "");
-    HuwelijksplannerAPI.getAvailability({
-      interval: "PT1H",
-      start: today,
-    }).then((data) => {
-      setResults(data);
+    AvailabilitycheckService.availabilitycheckGetCollection({
+      interval: "PT2H",
+      start: format(startOfMonth(date.getMonth()), "yyyy-MM-dd"),
+      stop: format(lastDayOfMonth(date.getMonth()), "yyyy-MM-dd"),
+    }).then((result) => {
+      console.log(result);
     });
-  }, []);
-
-  useEffect(() => {
-    loadEvents();
-  }, [selectedDate, loadEvents]);
-
-  const onChangeDateHandler = (event: ChangeEvent<HTMLInputElement>) => {
-    setSelectedLocationAndDate(event.target.value);
   };
 
-  const onSelectedDateAndLocationSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    // const data = {
-    //   trouw_optie: query.slug,
-    //   locatie_id: selectedLocationAndDate,
-    // };
-
-    if (selectedLocationAndDate) {
-      push("/voorgenomen-huwelijk");
-    } else {
-      throw new Error("please, select a date!");
-    }
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    console.log(event);
   };
 
   return (
@@ -103,7 +78,7 @@ const BlogPost: NextPage = () => {
           <PageContent>
             <BackLink href="/trouw-opties/">← Terug</BackLink>
             <PageContentMain>
-              <form onSubmit={onSelectedDateAndLocationSubmit}>
+              <form onSubmit={onSubmit}>
                 <HeadingGroup>
                   <Heading1>{t("huwelijksplanner-step-2:heading-1")}</Heading1>
                   {/*TODO: Step indicator component */}
@@ -117,55 +92,8 @@ const BlogPost: NextPage = () => {
                 </Paragraph>
                 <section>
                   <FormField>
-                    <Calendar onCalendarClick={(date: string) => setSelectedDate(date)} />
+                    <Calendar onCalendarClick={(date: string) => onCalendarDateSelected(new Date(date))} />
                   </FormField>
-                  <Fieldset>
-                    <FieldsetLegend>Flits/balie-huwelijk — Stadskantoor</FieldsetLegend>
-                    {getEvents("flits-balie-huwelijk", selectedDate).map((event) => (
-                      <FormField key={event.id} type="radio">
-                        <RadioButton2
-                          novalidate={true}
-                          id={event.id}
-                          name="event"
-                          value={event.id}
-                          required
-                          onChange={onChangeDateHandler}
-                        />
-                        <FormLabel htmlFor={event.id} type="radio">
-                          <span aria-label="negen uur tot tien over negen">
-                            <TimeValue dateTime={event.startDateTime} locale={locale} />
-                            {" – "}
-                            <TimeValue dateTime={event.endDateTime} locale={locale} />
-                            {" uur"}
-                          </span>
-                        </FormLabel>
-                      </FormField>
-                    ))}
-                  </Fieldset>
-                  <Fieldset>
-                    <FieldsetLegend>Uitgebreid trouwen — Zelf de plaats bepalen</FieldsetLegend>
-                    {getEvents("uitgebreid-huwelijk", selectedDate).map((event) => (
-                      <FormField key={event.id}>
-                        <RadioButton2
-                          novalidate={true}
-                          id={event.id}
-                          name="event"
-                          value={event.id}
-                          required
-                          onChange={onChangeDateHandler}
-                        />
-                        <FormLabel htmlFor={event.id}>
-                          <span aria-label="negen uur tot tien over negen">
-                            <TimeValue dateTime={event.startDateTime} locale={locale} />
-                            {" – "}
-                            <TimeValue dateTime={event.endDateTime} locale={locale} />
-                            {" uur"}
-                          </span>
-                        </FormLabel>
-                      </FormField>
-                    ))}
-                  </Fieldset>
-
                   <ButtonGroup>
                     <Button type="submit" appearance="primary-action-button">
                       Ja, dit wil ik!
@@ -192,4 +120,4 @@ const BlogPost: NextPage = () => {
   );
 };
 
-export default BlogPost;
+export default PlanningFormPage;

--- a/pages/trouw-opties/index.tsx
+++ b/pages/trouw-opties/index.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { FormEvent, useContext, useState } from "react";
+import { FormEvent, useCallback, useContext, useState } from "react";
 import {
   Aside,
   BackLink,
@@ -26,6 +26,7 @@ import { PageFooterTemplate } from "../../src/components/huwelijksplanner/PageFo
 import { PageHeaderTemplate } from "../../src/components/huwelijksplanner/PageHeaderTemplate";
 import { MarriageOptionsContext } from "../../src/context/MarriageOptionsContext";
 import { RegistrationType } from "../../src/data/huwelijksplanner-state";
+import { SdgproductService } from "../../src/generated";
 
 export const getServerSideProps = async ({ locale }: { locale: string }) => ({
   props: {
@@ -35,12 +36,21 @@ export const getServerSideProps = async ({ locale }: { locale: string }) => ({
 
 export default function MultistepForm1() {
   const { t } = useTranslation(["common", "huwelijksplanner-step-1"]);
-  const { replace } = useRouter();
+  const { push } = useRouter();
   const [marriageOptions, setMarriageOptions] = useContext(MarriageOptionsContext);
 
-  const onWeddingOptionsSubmit = (weddingType: RegistrationType) => {
-    setMarriageOptions({ ...marriageOptions, "registration-type": weddingType });
-    replace(`/trouw-opties/${weddingType}`);
+  const onMarriageOptionSubmit = (weddingType: RegistrationType) => {
+    SdgproductService.sdgproductGetCollection({
+      upnLabel: weddingType as string,
+    }).then((result) => {
+      const productId = result.results[0].id as string;
+      setMarriageOptions({
+        ...marriageOptions,
+        "registration-type": weddingType,
+        productId: productId,
+      });
+      push(`/trouw-opties/${weddingType}`);
+    });
   };
 
   return (
@@ -70,7 +80,7 @@ export default function MultistepForm1() {
                   name="type"
                   value="huwelijk"
                   appearance="primary-action-button"
-                  onClick={() => onWeddingOptionsSubmit("huwelijk")}
+                  onClick={() => onMarriageOptionSubmit("huwelijk")}
                 >
                   Trouwen plannen <UtrechtIconArrow />
                 </Button>
@@ -79,7 +89,7 @@ export default function MultistepForm1() {
                   name="type"
                   value="geregistreerd-partnerschap"
                   appearance="primary-action-button"
-                  onClick={() => onWeddingOptionsSubmit("geregistreerd-partnerschap")}
+                  onClick={() => onMarriageOptionSubmit("geregistreerd-partnerschap")}
                 >
                   Geregistreerd partnerschap plannen
                   <UtrechtIconArrow />

--- a/src/data/huwelijksplanner-state.ts
+++ b/src/data/huwelijksplanner-state.ts
@@ -145,17 +145,12 @@ interface Witness extends Invitee {
 
 export type RegistrationType = 'huwelijk' | 'geregistreerd-partnerschap';
 
-export type CeremonyType =
-  | 'eenvoudig-huwelijk'
-  | 'flits-balie-huwelijk'
-  | 'geregistreerd-partnerschap'
-  | 'uitgebreid-huwelijk';
-
 export interface HuwelijksplannerState {
+  ambtenaar?: string;
   partnerInvitation?: Invitee;
   partners: HuwelijksplannerPartner[];
   witnesses: Witness[];
-  'ceremony-type'?: CeremonyType;
+  'ceremony-type'?: string;
   'ceremony-location'?: string;
   'ceremony-start'?: string;
   'ceremony-end'?: string;

--- a/src/data/huwelijksplanner-state.ts
+++ b/src/data/huwelijksplanner-state.ts
@@ -161,6 +161,7 @@ export interface HuwelijksplannerState {
   'ceremony-end'?: string;
   'ceremony-price'?: string;
   'registration-type'?: RegistrationType;
+  productId?: string;
   reservation?: Reservation;
   cancelled?: boolean;
   cancelable?: boolean;

--- a/src/hooks/useAvailabilitycheckGetCollection.tsx
+++ b/src/hooks/useAvailabilitycheckGetCollection.tsx
@@ -1,0 +1,56 @@
+import { format } from "date-fns";
+import React, { useEffect, useState } from "react";
+import { CeremonyData } from "./useSdgProductGetItem";
+import { AvailabilitycheckService } from "../generated";
+import { ApiError } from "../openapi/core/ApiError";
+
+export type AvailabilitySlot = {
+  resources: string[];
+  start: string;
+  stop: string;
+};
+
+export type Availabilities = {
+  [key: string]: Array<AvailabilitySlot>;
+};
+
+export type AvailabilitycheckGetCollectionInput = {
+  ceremonyData: CeremonyData[];
+  interval: string;
+  stop: Date;
+  start: Date;
+};
+
+const dateFormat = "yyyy-MM-dd";
+
+export const useAvailabilitycheckGetCollection = (input: AvailabilitycheckGetCollectionInput) => {
+  const [data, setData] = useState<Availabilities>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<ApiError>();
+
+  useEffect(() => {
+    if (input.ceremonyData.length === 0) return;
+
+    setLoading(true);
+    AvailabilitycheckService.availabilitycheckGetCollection({
+      resourcesCould: input.ceremonyData.map((ceremony) => ceremony.id),
+      interval: input.interval,
+      start: format(input.start, dateFormat),
+      stop: format(input.stop, dateFormat),
+    })
+      .then(
+        (response) => {
+          const availabilityResults: Availabilities = response as any;
+          setData(availabilityResults);
+        },
+        (error) => {
+          setError(error);
+        }
+      )
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [input.ceremonyData, input.start.toISOString()]);
+
+  return [data, loading, error] as const;
+};

--- a/src/hooks/useSdgProductGetItem.tsx
+++ b/src/hooks/useSdgProductGetItem.tsx
@@ -5,7 +5,7 @@ import { SDGProduct, SdgproductService } from "../generated";
 import { ApiError } from "../openapi/core/ApiError";
 
 export type CeremonyData = {
-  type: CeremonyType;
+  type: string;
   id: string;
   locationId: string;
   ambtenaarId: string;

--- a/src/hooks/useSdgProductGetItem.tsx
+++ b/src/hooks/useSdgProductGetItem.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+import { CeremonyType } from "../data/huwelijksplanner-state";
+import { resolveEmbedded } from "../embedded";
+import { SDGProduct, SdgproductService } from "../generated";
+import { ApiError } from "../openapi/core/ApiError";
+
+export type CeremonyData = {
+  type: CeremonyType;
+  id: string;
+  locationId: string;
+  ambtenaarId: string;
+};
+
+const mapToCeremonyData = (products: SDGProduct): CeremonyData[] => {
+  return products.gerelateerdeProducten.map((ceremony: SDGProduct) => ({
+    id: ceremony.id as string,
+    type: ceremony.upnLabel as CeremonyType,
+    locationId: ceremony.gerelateerdeProducten[0].id,
+    ambtenaarId: ceremony.gerelateerdeProducten[0].gerelateerdeProducten[0].id,
+  }));
+};
+
+export const useSdgProductGetItem = (id: string | undefined) => {
+  const [data, setData] = useState<CeremonyData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<ApiError>();
+
+  useEffect(() => {
+    if (id === undefined) return;
+
+    setLoading(true);
+    SdgproductService.sdgproductGetItem({ id: id })
+      .then(
+        (response) => {
+          const mappedResult = mapToCeremonyData(resolveEmbedded(response));
+          setData(mappedResult);
+        },
+        (error) => {
+          setError(error);
+        }
+      )
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [id]);
+
+  return [data, loading, error] as const;
+};

--- a/src/hooks/useSdgProductGetItem.tsx
+++ b/src/hooks/useSdgProductGetItem.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { CeremonyType } from "../data/huwelijksplanner-state";
 import { resolveEmbedded } from "../embedded";
 import { SDGProduct, SdgproductService } from "../generated";
 import { ApiError } from "../openapi/core/ApiError";
@@ -14,7 +13,7 @@ export type CeremonyData = {
 const mapToCeremonyData = (products: SDGProduct): CeremonyData[] => {
   return products.gerelateerdeProducten.map((ceremony: SDGProduct) => ({
     id: ceremony.id as string,
-    type: ceremony.upnLabel as CeremonyType,
+    type: ceremony.upnLabel as string,
     locationId: ceremony.gerelateerdeProducten[0].id,
     ambtenaarId: ceremony.gerelateerdeProducten[0].gerelateerdeProducten[0].id,
   }));

--- a/src/openapi/core/OpenAPI.ts
+++ b/src/openapi/core/OpenAPI.ts
@@ -26,8 +26,5 @@ export const OpenAPI: OpenAPIConfig = {
   TOKEN: undefined,
   USERNAME: undefined,
   PASSWORD: undefined,
-  HEADERS: {
-    Authorization: process.env.NEXT_PUBLIC_API_TOKEN ?? '',
-  },
   ENCODE_PATH: undefined,
 };

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -15,6 +15,14 @@
   --utrecht-form-fieldset-margin-block-end: var(--utrecht-space-block-sm) !important;
 }
 
+.utrecht-form-fieldset__legend {
+  --utrecht-form-fieldset-legend-text-transform: none;
+}
+
+.utrecht-form-field--radio .utrecht-paragraph {
+  --utrecht-space-around: 0;
+}
+
 .utrecht-button-group:not(.utrecht-button-group--vertical) .utrecht-button-link {
   --utrecht-button-padding-inline-end: 16px !important;
   --utrecht-button-padding-inline-start: 16px !important;
@@ -41,20 +49,6 @@ body {
   --utrecht-form-fieldset-legend-text-transform: var(--utrecht-form-label-text-transform);
   --utrecht-form-fieldset-legend-margin-block-end: var(--utrecht-form-label-margin-block-end);
   --utrecht-form-fieldset-legend-margin-block-start: var(--utrecht-form-label-margin-block-start);
-}
-
-.todo-radio-group--inline {
-  --utrecht-form-field-margin-block-end: 0;
-  --utrecht-form-field-margin-block-start: 0;
-  display: inline-flex;
-  gap: var(--todo-radio-group-gap);
-}
-
-.todo-form--distanced {
-  margin-block-end: var(--todo-form-margin-block-end, 0);
-  margin-block-start: var(--todo-form-margin-block-start, 0);
-  margin-inline-end: var(--todo-form-margin-inline-end, 0);
-  margin-inline-start: var(--todo-form-margin-inline-start, 0);
 }
 
 .utrecht-form-label--disabled {


### PR DESCRIPTION
This CR adds the required API calls to show the user calendar slot data on the step 2 page. 

**Changes**
- Add request to `SdgproductService` to get the related available products
- Add follow-up request to `AvailabilitycheckService` to get available timeslots for products
- Add support for `UnavailableDates` (not visible because all test data has an available slot on all days)
- Update state object to support product ID
- Show dates as properly localised strings
- Remove slot selection when switchin days
- Move API calls into custom hooks
- Save the selection into a state so we can implement onSubmit when we move to the next page!

**Known issues to be resolved in follow-up**
- The datepicker component is missing support to implement some of the functionality we have defined as required for this page. For example, there is always a visibly selected date, even though we want to start with no selected date. We are unable to block dates in the past, and we are unable to respond to month change events.