### PR TITLE
fix: submit persoonsgegevens while loading huwelijk

### DIFF
--- a/pages/persoonsgegevens/[person].tsx
+++ b/pages/persoonsgegevens/[person].tsx
@@ -232,7 +232,12 @@ export default function MultistepForm1() {
                     />
                   </FormField>
                   <DeclarationCheckboxGroup register={register} checkboxData={checkboxData} />
-                  <Button disabled={!formState.isValid} type="submit" name="type" appearance="primary-action-button">
+                  <Button
+                    disabled={!formState.isValid || loading}
+                    type="submit"
+                    name="type"
+                    appearance="primary-action-button"
+                  >
                     Contactgegevens opslaan
                   </Button>
                 </section>


### PR DESCRIPTION
This change disables the submit button while the huwelijk initialisation call is still ongoing