### PR TITLE
fix: use person data on persoonsgegevens/success

### DIFF
--- a/pages/persoonsgegevens/succes.tsx
+++ b/pages/persoonsgegevens/succes.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useContext } from "react";
 import {
   ButtonGroup,
   ButtonLink,
@@ -23,7 +24,7 @@ import {
 } from "../../src/components";
 import { PageFooterTemplate } from "../../src/components/huwelijksplanner/PageFooterTemplate";
 import { PageHeaderTemplate } from "../../src/components/huwelijksplanner/PageHeaderTemplate";
-import { exampleState } from "../../src/data/huwelijksplanner-state";
+import { MarriageOptionsContext } from "../../src/context/MarriageOptionsContext";
 
 export const getServerSideProps = async ({ locale }: { locale: string }) => ({
   props: {
@@ -33,10 +34,9 @@ export const getServerSideProps = async ({ locale }: { locale: string }) => ({
 
 export default function MultistepForm1() {
   const { t } = useTranslation(["common", "huwelijksplanner-step-5", "form"]);
-  const data = { ...exampleState };
+  const [marriageOptions] = useContext(MarriageOptionsContext);
   const { locale } = useRouter();
-  // const applicant = data.partners[1];
-  const partner = data.partners[0];
+  const contact = marriageOptions.partners[0]?.contact;
 
   return (
     <Surface>
@@ -61,16 +61,17 @@ export default function MultistepForm1() {
                   <Paragraph lead>{t("common:step-n-of-m", { n: 3, m: 5 })} — Meld je voorgenomen huwelijk</Paragraph>
                 </HeadingGroup>
                 {/*TODO: Banner / card */}
-                {data["reservation"] ? (
-                  <ReservationCard reservation={data["reservation"]} locale={locale || "en"} />
+                {marriageOptions.reservation ? (
+                  <ReservationCard reservation={marriageOptions.reservation} locale={locale || "en"} />
                 ) : (
                   ""
                 )}
                 <section>
                   <Heading2>Gelukt</Heading2>
                   <Paragraph>
-                    We hebben jouw gegevens gekoppeld aan die van <DataNoTranslate>{partner["name"]}</DataNoTranslate>.
-                    Jullie kunnen nu verder gaan met het plannen van jullie huwelijk.
+                    We hebben jouw gegevens gekoppeld aan die van{" "}
+                    <DataNoTranslate>{`${contact.voornaam} ${contact.achternaam}`}</DataNoTranslate>. Jullie kunnen nu
+                    verder gaan met het plannen van jullie huwelijk.
                   </Paragraph>
                   <ButtonGroup>
                     <Link passHref href="/voorgenomen-huwelijk/getuigen">

--- a/src/data/huwelijksplanner-state.ts
+++ b/src/data/huwelijksplanner-state.ts
@@ -126,6 +126,7 @@ export interface HuwelijksplannerPartner
     Partial<Email>,
     Partial<Salutation>,
     Partial<IndicatieCurateleRegister> {
+  contact: { voornaam: string; achternaam: string };
   _self: { id: string };
   'marital-status'?: string;
   'declaration-checkbox-list'?: DeclarationCheckboxList;
@@ -191,6 +192,10 @@ export const exampleState: HuwelijksplannerState = {
   },
   partners: [
     {
+      contact: {
+        voornaam: 'Anne Nico Johannes',
+        achternaam: 'Deursen',
+      },
       _self: {
         id: '567EE1FC1C-A28A-43E7-8950-769E9',
       },
@@ -219,6 +224,10 @@ export const exampleState: HuwelijksplannerState = {
     {
       _self: {
         id: '567EE1FC1C-A28A-43E7-8950-769E9',
+      },
+      contact: {
+        voornaam: 'Sanne',
+        achternaam: 'Broecke',
       },
       id: '67EEFC1C-A28A-43E7-8950-76C289E905C7',
       name: 'Sanne van den Broecke',


### PR DESCRIPTION
Small fix to show the actual marriage partner's full name rather than the example state.