### PR TITLE
feat: extras page

### DIFF
--- a/pages/extra/index.tsx
+++ b/pages/extra/index.tsx
@@ -115,7 +115,7 @@ export default function MultistepForm1() {
                     </FormField>
                   </Fieldset>
                   <Button type="submit" name="type" appearance="primary-action-button">
-                    Deze wil ik hebben
+                    Bevestigen
                   </Button>
                 </section>
               </form>

--- a/pages/extra/index.tsx
+++ b/pages/extra/index.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { useContext } from "react";
+import { useContext, useId } from "react";
 import { useForm } from "react-hook-form";
 import {
   Button,
@@ -43,13 +43,13 @@ export default function MultistepForm1() {
   const { t } = useTranslation(["common", "huwelijksplanner-step-5", "form"]);
   const [marriageOptions] = useContext(MarriageOptionsContext);
   const { locale = "nl", push } = useRouter();
-  const [data, isLoading] = useSdgProductGetCollection("trouwboekje");
+  const [certificate, isLoading] = useSdgProductGetCollection("trouwboekje");
   const { register, handleSubmit } = useForm<FormData>();
 
   const certificateRadioName = "marriage-certificate-kind";
+  const noCertificateId = useId();
 
   const onMarriageCertificateKindSubmit = (formData: FormData) => {
-    push("/voorgenomen-huwelijk/checken");
   };
 
   return (
@@ -84,29 +84,37 @@ export default function MultistepForm1() {
                       <Image src="/img/voorbeeld-trouwboekjes.jpg" width={600} height={385} alt="trouwboekjes" />
                     </Paragraph>
                     <FormField type="radio">
-                      <RadioButton2 id="1" defaultChecked={true} {...register(certificateRadioName)} />
-                      <FormLabel htmlFor="1" type="radio">
-                        Nee, wij willen geen trouwboekje
-                      </FormLabel>
+                      <Paragraph className="utrecht-form-field__label utrecht-form-field__label--radio">
+                        <FormLabel htmlFor={noCertificateId} type="radio">
+                          <RadioButton2
+                            className="utrecht-form-field__input"
+                            id={noCertificateId}
+                            defaultChecked={true}
+                            value={"none"}
+                            {...register(certificateRadioName)}
+                          />
+                          Nee, wij willen geen trouwboekje
+                        </FormLabel>
+                      </Paragraph>
                     </FormField>
-                    <FormField type="radio">
-                      <RadioButton2 id="2" {...register(certificateRadioName)} />
-                      <FormLabel htmlFor="2" type="radio">
-                        Wit lederen omslag (€ 32,50)
-                      </FormLabel>
-                    </FormField>
-                    <FormField type="radio">
-                      <RadioButton2 id="3" {...register(certificateRadioName)} />
-                      <FormLabel htmlFor="3" type="radio">
-                        Donkerblauw lederen omslag (€ 32,50)
-                      </FormLabel>
-                    </FormField>
-                    <FormField type="radio">
-                      <RadioButton2 id="4" {...register(certificateRadioName)} />
-                      <FormLabel htmlFor="4" type="radio">
-                        Rood kunstlederen omslag (€ 30,00)
-                      </FormLabel>
-                    </FormField>
+                    {certificate &&
+                      certificate.vertalingen.map(
+                        (vertaling: { id: string; specifiekeTekst: string; kosten: string }) => (
+                          <FormField key={vertaling.id} type="radio">
+                            <Paragraph className="utrecht-form-field__label utrecht-form-field__label--radio">
+                              <FormLabel htmlFor={vertaling.id} type="radio">
+                                <RadioButton2
+                                  className="utrecht-form-field__input"
+                                  id={vertaling.id}
+                                  value={vertaling.id}
+                                  {...register(certificateRadioName)}
+                                />
+                                {vertaling.specifiekeTekst} ({vertaling.kosten})
+                              </FormLabel>
+                            </Paragraph>
+                          </FormField>
+                        )
+                      )}
                   </Fieldset>
                   <Button type="submit" name="type" appearance="primary-action-button">
                     Bevestigen

--- a/pages/extra/index.tsx
+++ b/pages/extra/index.tsx
@@ -1,11 +1,12 @@
-import { FormField, FormLabel } from "@utrecht/component-library-react";
+import { ButtonGroup, FormField, FormLabel } from "@utrecht/component-library-react";
 import Head from "next/head";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { useContext, useId, useState } from "react";
+import React, { useContext, useId, useState } from "react";
 import { useForm } from "react-hook-form";
+import Skeleton from "react-loading-skeleton";
 import {
   Button,
   Document,
@@ -44,7 +45,7 @@ export default function MultistepForm1() {
   const { t } = useTranslation(["common", "huwelijksplanner-step-5", "form"]);
   const [marriageOptions, setMarriageOptions] = useContext(MarriageOptionsContext);
   const { locale = "nl", push } = useRouter();
-  const [certificate, isLoading] = useSdgProductGetCollection("trouwboekje");
+  const [certificate, productLoading] = useSdgProductGetCollection("trouwboekje");
   const { register, handleSubmit } = useForm<FormData>();
   const reservation = marriageOptions.reservation;
   const [saving, setSaving] = useState(false);
@@ -107,48 +108,59 @@ export default function MultistepForm1() {
                     Een trouwboekje hoort niet meer standaard bij een huwelijk. Je kunt het wel bestellen als extra -
                     dan is het een mooie aandenken aan jullie trouwdag.
                   </Paragraph>
-                  <Fieldset style={{ width: "fit-content" }}>
-                    <FieldsetLegend>Trouwboekje</FieldsetLegend>
-                    <Paragraph>
-                      <Image src="/img/voorbeeld-trouwboekjes.jpg" width={600} height={385} alt="trouwboekjes" />
-                    </Paragraph>
-                    <FormField type="radio">
-                      <Paragraph className="utrecht-form-field__label utrecht-form-field__label--radio">
-                        <FormLabel htmlFor={noCertificateId} type="radio">
-                          <RadioButton2
-                            className="utrecht-form-field__input"
-                            id={noCertificateId}
-                            defaultChecked={true}
-                            value={"none"}
-                            {...register(certificateRadioName)}
-                          />
-                          Nee, wij willen geen trouwboekje
-                        </FormLabel>
+                  {productLoading ? (
+                    <Skeleton height={"250px"} />
+                  ) : (
+                    <Fieldset style={{ width: "fit-content" }}>
+                      <FieldsetLegend>Trouwboekje</FieldsetLegend>
+                      <Paragraph>
+                        <Image src="/img/voorbeeld-trouwboekjes.jpg" width={600} height={385} alt="trouwboekjes" />
                       </Paragraph>
-                    </FormField>
-                    {certificate &&
-                      certificate.vertalingen.map(
-                        (vertaling: { id: string; specifiekeTekst: string; kosten: string }) => (
-                          <FormField key={vertaling.id} type="radio">
-                            <Paragraph className="utrecht-form-field__label utrecht-form-field__label--radio">
-                              <FormLabel htmlFor={vertaling.id} type="radio">
-                                <RadioButton2
-                                  className="utrecht-form-field__input"
-                                  id={vertaling.id}
-                                  value={vertaling.id}
-                                  {...register(certificateRadioName)}
-                                />
-                                {vertaling.specifiekeTekst} ({vertaling.kosten})
-                              </FormLabel>
-                            </Paragraph>
-                          </FormField>
-                        )
-                      )}
-                  </Fieldset>
-                  <Button disabled={saving} type="submit" name="type" appearance="primary-action-button">
+                      <FormField type="radio">
+                        <Paragraph className="utrecht-form-field__label utrecht-form-field__label--radio">
+                          <FormLabel htmlFor={noCertificateId} type="radio">
+                            <RadioButton2
+                              className="utrecht-form-field__input"
+                              id={noCertificateId}
+                              defaultChecked={true}
+                              value={"none"}
+                              {...register(certificateRadioName)}
+                            />
+                            Nee, wij willen geen trouwboekje
+                          </FormLabel>
+                        </Paragraph>
+                      </FormField>
+                      {certificate &&
+                        certificate.vertalingen.map(
+                          (vertaling: { id: string; specifiekeTekst: string; kosten: string }) => (
+                            <FormField key={vertaling.id} type="radio">
+                              <Paragraph className="utrecht-form-field__label utrecht-form-field__label--radio">
+                                <FormLabel htmlFor={vertaling.id} type="radio">
+                                  <RadioButton2
+                                    className="utrecht-form-field__input"
+                                    id={vertaling.id}
+                                    value={vertaling.id}
+                                    {...register(certificateRadioName)}
+                                  />
+                                  {vertaling.specifiekeTekst} ({vertaling.kosten})
+                                </FormLabel>
+                              </Paragraph>
+                            </FormField>
+                          )
+                        )}
+                    </Fieldset>
+                  )}
+                </section>
+                <ButtonGroup>
+                  <Button
+                    disabled={saving || productLoading}
+                    type="submit"
+                    name="type"
+                    appearance="primary-action-button"
+                  >
                     Bevestigen
                   </Button>
-                </section>
+                </ButtonGroup>
               </form>
             </PageContentMain>
           </PageContent>

--- a/pages/extra/index.tsx
+++ b/pages/extra/index.tsx
@@ -4,7 +4,8 @@ import Image from "next/image";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { FormEvent } from "react";
+import { useContext } from "react";
+import { useForm } from "react-hook-form";
 import {
   Button,
   Document,
@@ -19,13 +20,14 @@ import {
   PageFooter,
   PageHeader,
   Paragraph,
+  RadioButton2,
   ReservationCard,
   Surface,
 } from "../../src/components";
-import { Checkbox2, RadioButton2 } from "../../src/components";
 import { PageFooterTemplate } from "../../src/components/huwelijksplanner/PageFooterTemplate";
 import { PageHeaderTemplate } from "../../src/components/huwelijksplanner/PageHeaderTemplate";
-import { exampleState } from "../../src/data/huwelijksplanner-state";
+import { MarriageOptionsContext } from "../../src/context/MarriageOptionsContext";
+import { useSdgProductGetCollection } from "../../src/hooks/useSdgProductGetCollection";
 
 export const getServerSideProps = async ({ locale }: { locale: string }) => ({
   props: {
@@ -33,13 +35,20 @@ export const getServerSideProps = async ({ locale }: { locale: string }) => ({
   },
 });
 
+type FormData = {
+  "marriage-certificate-kind": string;
+};
+
 export default function MultistepForm1() {
   const { t } = useTranslation(["common", "huwelijksplanner-step-5", "form"]);
-  const data = { ...exampleState };
+  const [marriageOptions] = useContext(MarriageOptionsContext);
   const { locale = "nl", push } = useRouter();
+  const [data, isLoading] = useSdgProductGetCollection("trouwboekje");
+  const { register, handleSubmit } = useForm<FormData>();
 
-  const onMarriageCertificateKindSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const certificateRadioName = "marriage-certificate-kind";
+
+  const onMarriageCertificateKindSubmit = (formData: FormData) => {
     push("/voorgenomen-huwelijk/checken");
   };
 
@@ -55,15 +64,14 @@ export default function MultistepForm1() {
           </PageHeader>
           <PageContent>
             <PageContentMain>
-              <form onSubmit={onMarriageCertificateKindSubmit}>
+              <form onSubmit={handleSubmit(onMarriageCertificateKindSubmit)}>
                 <HeadingGroup>
                   <Heading1>{t("huwelijksplanner-step-5:heading-1")}</Heading1>
-                  {/*TODO: Previous button */}
-                  {/*TODO: Step indicator component */}
                   <Paragraph lead>Stap 3 — Meld je voorgenomen huwelijk</Paragraph>
                 </HeadingGroup>
-                {/*TODO: Banner / card */}
-                {data["reservation"] ? <ReservationCard reservation={data["reservation"]} locale={locale} /> : ""}
+                {marriageOptions.reservation && (
+                  <ReservationCard reservation={marriageOptions.reservation} locale={locale} />
+                )}
                 <section>
                   <Heading2>Kies je extra’s</Heading2>
                   <Paragraph>
@@ -75,32 +83,32 @@ export default function MultistepForm1() {
                     <Paragraph>
                       <Image src="/img/voorbeeld-trouwboekjes.jpg" width={600} height={385} alt="trouwboekjes" />
                     </Paragraph>
-                    <FormField type="checkbox">
-                      <Checkbox2 id="marriage-certificate-agreement" />
-                      <FormLabel htmlFor="marriage-certificate-agreement" type="checkbox">
-                        Ja, wij willen een trouwboekje
+                    <FormField type="radio">
+                      <RadioButton2 id="1" defaultChecked={true} {...register(certificateRadioName)} />
+                      <FormLabel htmlFor="1" type="radio">
+                        Nee, wij willen geen trouwboekje
                       </FormLabel>
                     </FormField>
                     <FormField type="radio">
-                      <RadioButton2 id="1" name="marriage-certificate-kind" />
+                      <RadioButton2 id="1" {...register(certificateRadioName)} />
                       <FormLabel htmlFor="1" type="radio">
                         Wit lederen omslag (€ 32,50)
                       </FormLabel>
                     </FormField>
                     <FormField type="radio">
-                      <RadioButton2 id="2" name="marriage-certificate-kind" />
+                      <RadioButton2 id="2" {...register(certificateRadioName)} />
                       <FormLabel htmlFor="2" type="radio">
                         Wit lederen omslag (€ 32,50)
                       </FormLabel>
                     </FormField>
                     <FormField type="radio">
-                      <RadioButton2 id="3" name="marriage-certificate-kind" />
+                      <RadioButton2 id="3" {...register(certificateRadioName)} />
                       <FormLabel htmlFor="3" type="radio">
                         Donkerblauw lederen omslag (€ 32,50)
                       </FormLabel>
                     </FormField>
                     <FormField type="radio">
-                      <RadioButton2 id="4" name="marriage-certificate-kind" />
+                      <RadioButton2 id="4" {...register(certificateRadioName)} />
                       <FormLabel htmlFor="4" type="radio">
                         Rood kunstlederen omslag (€ 30,00)
                       </FormLabel>

--- a/pages/extra/index.tsx
+++ b/pages/extra/index.tsx
@@ -90,12 +90,6 @@ export default function MultistepForm1() {
                       </FormLabel>
                     </FormField>
                     <FormField type="radio">
-                      <RadioButton2 id="1" {...register(certificateRadioName)} />
-                      <FormLabel htmlFor="1" type="radio">
-                        Wit lederen omslag (€ 32,50)
-                      </FormLabel>
-                    </FormField>
-                    <FormField type="radio">
                       <RadioButton2 id="2" {...register(certificateRadioName)} />
                       <FormLabel htmlFor="2" type="radio">
                         Wit lederen omslag (€ 32,50)

--- a/src/components/RadioButton2.tsx
+++ b/src/components/RadioButton2.tsx
@@ -1,15 +1,21 @@
 import { RadioButton } from "@utrecht/component-library-react";
-import React, { InputHTMLAttributes } from "react";
+import React, { ForwardedRef, InputHTMLAttributes } from "react";
+import { Checkbox2 } from "./Checkbox2";
 
 interface RadioButton2Props extends InputHTMLAttributes<HTMLInputElement> {
   invalid?: boolean;
   novalidate?: boolean;
 }
 
-export const RadioButton2: React.FC<RadioButton2Props> = ({ required, novalidate, ...props }) => (
-  <RadioButton
-    aria-required={(required && novalidate) || undefined}
-    required={required && !novalidate ? required : undefined}
-    {...props}
-  />
+export const RadioButton2: React.FC<RadioButton2Props> = React.forwardRef(
+  ({ required, novalidate, ...props }, ref: ForwardedRef<HTMLInputElement>) => (
+    <RadioButton
+      aria-required={(required && novalidate) || undefined}
+      required={required && !novalidate ? required : undefined}
+      ref={ref}
+      {...props}
+    />
+  )
 );
+
+RadioButton2.displayName = "RadioButton";

--- a/src/hooks/useSdgProductGetCollection.tsx
+++ b/src/hooks/useSdgProductGetCollection.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { resolveEmbedded } from "../embedded";
+import { SDGProduct, SdgproductService } from "../generated";
+import { ApiError } from "../openapi/core/ApiError";
+
+export const useSdgProductGetCollection = (productType: string) => {
+  const [data, setData] = useState<SDGProduct>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<ApiError>();
+
+  useEffect(() => {
+    if (!productType) {
+      return;
+    }
+
+    setLoading(true);
+    SdgproductService.sdgproductGetCollection({
+      upnLabel: productType,
+    })
+      .then(
+        (response) => {
+          const result = resolveEmbedded(response.results[0]);
+          setData(result);
+        },
+        (error) => {
+          setError(error);
+        }
+      )
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [productType]);
+
+  return [data, loading, error] as const;
+};


### PR DESCRIPTION
This PR adds the required logic for the `extra/index` page, which allows a user to add a marriage certificate book as an extra to their wedding. Upon submission, the chosen extra (or none if none is chosen) is added to the marriage entity in the backend).

**Not in scope!**
- Changing the order / navigation to reach the extras page, the desire is to put it as a page in between witness invites and paying, but now it's an option to skip extras and pay straight away
- The page after the extras page (`checken`) is not yet updated so the reservation card shows example marriage data.

<img width="822" alt="image" src="https://github.com/frameless/utrecht-huwelijksplanner/assets/24610692/4d0fd744-ae54-4de2-bb85-719b5cbb76da">
