### PR TITLE
feat: remove header and use divider

### DIFF
--- a/src/components/HeaderDivider.scss
+++ b/src/components/HeaderDivider.scss
@@ -1,0 +1,5 @@
+.utrecht-page-header-divider {
+  background-color: var(--utrecht-topnav-list-background-color);
+  grid-area: nav;
+  height: 2px;
+}

--- a/src/components/HeaderDivider.tsx
+++ b/src/components/HeaderDivider.tsx
@@ -1,0 +1,3 @@
+export const HeaderDivider = () => {
+  return <div className={"utrecht-page-header-divider"}></div>;
+};

--- a/src/components/HeaderNav.tsx
+++ b/src/components/HeaderNav.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React, { FC, ForwardedRef, forwardRef, HTMLAttributes } from "react";
+import { FC, ForwardedRef, forwardRef, HTMLAttributes } from "react";
 import { Link, LinkProps } from "./Link";
 
 export const HeaderNavLink: FC<LinkProps> = forwardRef(

--- a/src/components/huwelijksplanner/PageHeaderTemplate.tsx
+++ b/src/components/huwelijksplanner/PageHeaderTemplate.tsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 Robbert Broersma
  */
 
-import { HeaderNav, HeaderNavLink, LanguageToggleButtons, Link, Paragraph, UtrechtLogo } from "../index";
+import { HeaderDivider, LanguageToggleButtons, Link, Paragraph, UtrechtLogo } from "../index";
 
 export const PageHeaderTemplate = () => (
   <>
@@ -13,12 +13,6 @@ export const PageHeaderTemplate = () => (
       </Link>
     </Paragraph>
     <LanguageToggleButtons headingLevel={2} className="utrecht-page-header__alternate-lang-nav" />
-    <HeaderNav className="utrecht-page-header__nav">
-      <HeaderNavLink href="https://www.utrecht.nl/wonen-en-leven">Wonen en Leven</HeaderNavLink>
-      <HeaderNavLink href="https://www.utrecht.nl/zorg-en-onderwijs/">Zorg en Onderwijs</HeaderNavLink>
-      <HeaderNavLink href="https://www.utrecht.nl/werk-en-inkomen/">Werk en Inkomen</HeaderNavLink>
-      <HeaderNavLink href="https://www.utrecht.nl/ondernemen/">Ondernemen</HeaderNavLink>
-      <HeaderNavLink href="https://www.utrecht.nl/bestuur-en-organisatie/">Bestuur en Organisatie</HeaderNavLink>
-    </HeaderNav>
+    <HeaderDivider />
   </>
 );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -29,6 +29,7 @@ export { ReservationCard } from './huwelijksplanner/ReservationCard';
 export { SkipLink } from './SkipLink';
 export { UtrechtLogo } from './UtrechtLogo';
 export { ValueCurrency } from './ValueCurrency';
+export { HeaderDivider } from './HeaderDivider';
 export { PreHeading } from './PreHeading';
 export { HeadingGroup } from './HeadingGroup';
 export { FeedbackSection } from './FeedbackSection';

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -7,6 +7,7 @@
 @import "./src/components/Email";
 @import "./src/components/FeedbackSection";
 @import "./src/components/FormContent";
+@import "./src/components/HeaderDivider";
 @import "./src/components/HeadingGroup";
 @import "./src/components/PageContentMain";
 @import "./pages/gateway-login/index";


### PR DESCRIPTION
This PR removes the original navigation as agreed. For now, I have added a divider with the same background color as the nav to make transitions between pages with and without navigation blend together better.

<img width="782" alt="image" src="https://github.com/frameless/utrecht-huwelijksplanner/assets/24610692/964f6208-a5bb-48ff-b584-65ee06b8430c">
