### PR TITLE
fix: require email and phonenumber fields

### DIFF
--- a/pages/persoonsgegevens/[person].tsx
+++ b/pages/persoonsgegevens/[person].tsx
@@ -27,7 +27,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import React, { useCallback, useContext, useEffect, useId, useRef, useState } from "react";
 import { useForm, UseFormRegister } from "react-hook-form";
 import Skeleton from "react-loading-skeleton";
-import { Aside, Checkbox2, OptionalIndicator, PageContentMain, ReservationCard } from "../../src/components";
+import { Aside, Checkbox2, PageContentMain, ReservationCard } from "../../src/components";
 import { AddressDataList } from "../../src/components/huwelijksplanner/AddressDataList";
 import { PageFooterTemplate } from "../../src/components/huwelijksplanner/PageFooterTemplate";
 import { PageHeaderTemplate } from "../../src/components/huwelijksplanner/PageHeaderTemplate";
@@ -212,6 +212,7 @@ export default function MultistepForm1() {
                       id="tel"
                       type="tel"
                       autoComplete="tel"
+                      invalid={formState.errors.phoneNumber && formState.isSubmitted}
                       {...register("phoneNumber", { required: true })}
                     />
                   </FormField>
@@ -230,6 +231,7 @@ export default function MultistepForm1() {
                       type="email"
                       autoComplete="email"
                       aria-describedby="email-description"
+                      invalid={formState.errors.email && formState.isSubmitted}
                       {...register("email", { required: true })}
                     />
                   </FormField>

--- a/pages/persoonsgegevens/[person].tsx
+++ b/pages/persoonsgegevens/[person].tsx
@@ -205,23 +205,19 @@ export default function MultistepForm1() {
                   <p>Deze gegevens kun je zelf invullen of wijzigen.</p>
                   <FormField>
                     <p className="utrecht-form-field__label">
-                      <FormLabel htmlFor="tel">
-                        {t("form:tel")} <OptionalIndicator title={t("form:optional")} />
-                      </FormLabel>
+                      <FormLabel htmlFor="tel">{t("form:tel")}</FormLabel>
                     </p>
                     <Textbox
                       className="utrecht-form-field__input"
                       id="tel"
                       type="tel"
                       autoComplete="tel"
-                      {...register("phoneNumber")}
+                      {...register("phoneNumber", { required: true })}
                     />
                   </FormField>
                   <FormField>
                     <p className="utrecht-form-field__label">
-                      <FormLabel htmlFor="email">
-                        {t("form:email")} <OptionalIndicator title={t("form:optional")} />
-                      </FormLabel>
+                      <FormLabel htmlFor="email">{t("form:email")}</FormLabel>
                     </p>
                     <FormFieldDescription id="email-description">
                       We sturen je een bevestiging naar dit e-mailadres.
@@ -234,7 +230,7 @@ export default function MultistepForm1() {
                       type="email"
                       autoComplete="email"
                       aria-describedby="email-description"
-                      {...register("email")}
+                      {...register("email", { required: true })}
                     />
                   </FormField>
                   <DeclarationCheckboxGroup register={register} checkboxData={checkboxData} />


### PR DESCRIPTION
This change forces the user to enter an email and phone number. It uses the `react-use-form` hook dependency to validate whether or not a specific field is invalid and if a submission has been attempted, in which case the form field will receive the invalid attribute.

An improvement on this would be showing the error message per field better highlight and explain why a field is invalid

Resolves: #437