### PR TITLE
fix: prevent duplicate submit

### DIFF
--- a/pages/persoonsgegevens/[person].tsx
+++ b/pages/persoonsgegevens/[person].tsx
@@ -118,6 +118,7 @@ export default function MultistepForm1() {
   });
 
   const onContactDetailsSubmit = (data: FormData) => {
+    setLoading(true);
     if (huwelijkId) {
       HuwelijkService.huwelijkPatchItem({
         id: huwelijkId as string,
@@ -137,6 +138,7 @@ export default function MultistepForm1() {
         },
       }).then(() => {
         push(`/persoonsgegevens/succes?huwelijkId=${huwelijkId}`);
+        setLoading(false);
       });
     } else {
       AssentService.assentPatchItem({
@@ -154,6 +156,7 @@ export default function MultistepForm1() {
         },
       }).then(() => {
         push("/voorgenomen-huwelijk/partner");
+        setLoading(false);
       });
     }
   };


### PR DESCRIPTION
### Bugfix
Disables the submit button after the user submits successfully to avoid spam pressing the submit, firing off multiple requests and leading to unexpected behaviour. This might need a small rework to communicate more clearly why the button is disabled.