### PR TITLE
ci: enable auto versioning with sha

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -55,10 +55,10 @@ jobs:
           images: |
             ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value={{sha}},enable=${{ github.ref_type != 'tag' }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx


### PR DESCRIPTION
semantic versioning is manually

**Usage**:

from the `main` branch

```shell
git tag git tag v1.0.0
```

```shell
 git push origin v1.0.0
```